### PR TITLE
Bugs

### DIFF
--- a/src/DllInfo.cs
+++ b/src/DllInfo.cs
@@ -11,7 +11,7 @@ namespace RockLib.Interop
     /// </summary>
     internal sealed class DllInfo
     {
-        private static readonly IReadOnlyCollection<string> _assemblyManifestResourceNames = typeof(DllInfo).GetTypeInfo().Assembly.GetManifestResourceNames().Select(n => n.ToLowerInvariant()).ToList().AsReadOnly();
+        private static readonly IReadOnlyCollection<string> _assemblyManifestResourceNames = typeof(DllInfo).GetTypeInfo().Assembly.GetManifestResourceNames().ToList().AsReadOnly();
 
         private readonly TargetRuntime _targetRuntime;
         private readonly string _resourceName;
@@ -70,7 +70,7 @@ namespace RockLib.Interop
         {
             if (resourceName == null) throw new ArgumentNullException("resourceName");
             if (resourceName == "") throw new ArgumentException("'resourceName' must not be empty.", "resourceName");
-            if (!_assemblyManifestResourceNames.Contains(resourceName.ToLowerInvariant()))
+            if (!_assemblyManifestResourceNames.Contains(resourceName))
                 throw new ArgumentException(string.Format("Resource '{0}' was not found in the assembly manifest resource names: {1}",
                     resourceName, string.Join(", ", _assemblyManifestResourceNames.Select(n => "'" + n + "'"))), "resourceName");
 
@@ -80,7 +80,7 @@ namespace RockLib.Interop
                 {
                     if (additionalResourceName == null) throw new ArgumentException("Elements of 'additionalResourceNames' must not be null.", "additionalResourceNames");
                     if (additionalResourceName == "") throw new ArgumentException("Elements of 'additionalResourceNames' must not be empty.", "additionalResourceNames");
-                    if (!_assemblyManifestResourceNames.Contains(additionalResourceName.ToLowerInvariant()))
+                    if (!_assemblyManifestResourceNames.Contains(additionalResourceName))
                         throw new ArgumentException(string.Format("Additional resource '{0}' was not found in the assembly manifest resource names: {1}",
                             additionalResourceName, string.Join(", ", _assemblyManifestResourceNames.Select(n => "'" + n + "'"))), "additionalResourceNames");
                 }

--- a/src/EmbeddedNativeLibrary.cs
+++ b/src/EmbeddedNativeLibrary.cs
@@ -269,7 +269,7 @@ namespace RockLib.Interop
                     maybePointer.Exceptions);
             }
 
-#if NET40
+#if BEFORE_NET451
             return (TDelegate)(object)Marshal.GetDelegateForFunctionPointer(maybePointer.Value, typeof(TDelegate));
 #else
             return Marshal.GetDelegateForFunctionPointer<TDelegate>(maybePointer.Value);

--- a/src/EmbeddedNativeLibrary.cs
+++ b/src/EmbeddedNativeLibrary.cs
@@ -269,7 +269,11 @@ namespace RockLib.Interop
                     maybePointer.Exceptions);
             }
 
+#if NET40
+            return (TDelegate)(object)Marshal.GetDelegateForFunctionPointer(maybePointer.Value, typeof(TDelegate));
+#else
             return Marshal.GetDelegateForFunctionPointer<TDelegate>(maybePointer.Value);
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
- Add precompiler directive for .NET Framework 4.5 or below.
  - The generic `GetDelegateForFunctionPointer<TDelegate>` method was introduced in .NET Framework 4.5.1. 
  - Projects targeting .NET Framework 4.5 or below need to add the `BEFORE_NET451` symbol to their project in order for it to compile.
- Fix manifest resource name search
  - Doing the search in a case-insensitive manner was incorrect.